### PR TITLE
ExcludeAssets

### DIFF
--- a/src/RxBim.Application.Ribbon.Revit/Directory.Build.Props
+++ b/src/RxBim.Application.Ribbon.Revit/Directory.Build.Props
@@ -1,6 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
-        <ApiVersion>2.0.1</ApiVersion>
+        <ApiVersion>2.0.2-dev01</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/src/RxBim.Application.Ribbon.Revit/RxBim.Application.Ribbon.Revit.csproj
+++ b/src/RxBim.Application.Ribbon.Revit/RxBim.Application.Ribbon.Revit.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BimLab.Revit.AdWindows.2019" Version="1.0.1" />
-        <PackageReference Include="BimLab.Revit.Api.2019" Version="1.0.1" />
+        <PackageReference Include="BimLab.Revit.AdWindows.2019" Version="1.0.1" ExcludeAssets="runtime" />
+        <PackageReference Include="BimLab.Revit.Api.2019" Version="1.0.1" ExcludeAssets="runtime" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/RxBim.Logs.Revit/Directory.Build.Props
+++ b/src/RxBim.Logs.Revit/Directory.Build.Props
@@ -1,6 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
-        <ApiVersion>1.0.5</ApiVersion>
+        <ApiVersion>1.0.6-dev01</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/src/RxBim.Logs.Revit/RxBim.Logs.Revit.csproj
+++ b/src/RxBim.Logs.Revit/RxBim.Logs.Revit.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="BimLab.Revit.Api.2019" Version="1.0.1" PrivateAssets="all" />
+        <PackageReference Include="BimLab.Revit.Api.2019" Version="1.0.1" ExcludeAssets="runtime" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Чтобы не копировались dll апи ревита в папку сборки проекта.