### PR TITLE
Исправление AssemblyResolver

### DIFF
--- a/src/Core/RxBim.Shared/AssemblyResolver.cs
+++ b/src/Core/RxBim.Shared/AssemblyResolver.cs
@@ -70,7 +70,8 @@
 
             public bool IsResolve(string dllRequest)
             {
-                return dllRequest.StartsWith($"{DllName},", StringComparison.OrdinalIgnoreCase);
+                return dllRequest.Equals(DllName, StringComparison.OrdinalIgnoreCase)
+                    || dllRequest.StartsWith($"{DllName},", StringComparison.OrdinalIgnoreCase);
             }
 
             public Assembly LoadAssembly()

--- a/src/Core/RxBim.Shared/AssemblyResolver.cs
+++ b/src/Core/RxBim.Shared/AssemblyResolver.cs
@@ -70,6 +70,10 @@
 
             public bool IsResolve(string dllRequest)
             {
+                // Assembly FullName format: $"{Name}, {AssemblyVersion}, {Culture}, {PublicKeyToken}, {SpecialFlags}"
+                // more details on https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assemblyname
+                // or https://source.dot.net/System.Private.CoreLib/R/5feac5f806a6cd7f.html
+                // `Name` is required, other fields are optional and may be missing.
                 return dllRequest.Equals(DllName, StringComparison.OrdinalIgnoreCase)
                     || dllRequest.StartsWith($"{DllName},", StringComparison.OrdinalIgnoreCase);
             }


### PR DESCRIPTION
`RxBim.Shared.AssemblyResolver` не может разрешать зависимости вида: `Pik.Metro.dll`, `MdXaml.dll`, `PikTools.Logs.Elastic.1.1.2` и т.д. Во всех этих случаях в строке `dllRequest` приходит точное имя библиотеки, и символ `,` является избыточным (сборки без строгого имени?). В случае с `PikTools.Logs.Elastic.*` если во всех установленных плагинах используется одна общая версия библиотеки, то она как-то находится без использования `RxBim.Shared.AssemblyResolver`. Если же версии разные, то вторая и далее версии уже не находятся.