### PR TITLE
Исправлеие дублирования источников конфигурации в контейнере

### DIFF
--- a/src/Autocad/RxBim.Application.Ribbon.Autocad/Extensions/ContainerExtensions.cs
+++ b/src/Autocad/RxBim.Application.Ribbon.Autocad/Extensions/ContainerExtensions.cs
@@ -29,6 +29,22 @@
         }
 
         /// <summary>
+        /// Adds ribbon menu from action.
+        /// </summary>
+        /// <param name="services">DI container.</param>
+        /// <param name="builder">The ribbon builder.</param>
+        /// <param name="menuAssembly">Menu assembly.</param>
+        public static void AddAutocadMenu(
+            this IServiceCollection services,
+            Action<IServiceProvider, IRibbonBuilder> builder,
+            Assembly? menuAssembly = null)
+        {
+            menuAssembly ??= Assembly.GetCallingAssembly();
+            services.AddServices();
+            services.AddMenu<AutocadRibbonMenuBuilder>(builder, menuAssembly);
+        }
+
+        /// <summary>
         /// Adds ribbon menu from config.
         /// </summary>
         /// <param name="services">DI container.</param>

--- a/src/Core/RxBim.Application.Ribbon/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/RxBim.Application.Ribbon/Extensions/ServiceCollectionExtensions.cs
@@ -38,6 +38,31 @@
         }
 
         /// <summary>
+        /// Adds a plugin ribbon menu from an action.
+        /// </summary>
+        /// <param name="services">DI container.</param>
+        /// <param name="builder">The ribbon menu builder.</param>
+        /// <param name="assembly">
+        /// Menu definition assembly.
+        /// Used to get the command type from the command type name
+        /// and to define the root directory for relative icon paths.
+        /// </param>
+        public static void AddMenu<TBuilder>(
+            this IServiceCollection services,
+            Action<IServiceProvider, IRibbonBuilder> builder,
+            Assembly assembly)
+            where TBuilder : class, IRibbonMenuBuilder
+        {
+            services.AddBuilder<TBuilder>(assembly);
+            services.AddSingleton(sp =>
+            {
+                var ribbon = new RibbonBuilder();
+                builder(sp, ribbon);
+                return ribbon.Build();
+            });
+        }
+
+        /// <summary>
         /// Adds a plugin ribbon menu from configuration.
         /// </summary>
         /// <param name="services">DI container.</param>

--- a/src/Core/RxBim.Di/DiConfigurator.cs
+++ b/src/Core/RxBim.Di/DiConfigurator.cs
@@ -62,11 +62,10 @@
 
         private void AddConfigurations(Assembly assembly)
         {
-            var configurationBuilder = GetBaseConfigurationBuilder(assembly);
-            AddUserConfigurations(configurationBuilder);
+            AddUserConfigurations(() => CreateBaseConfigurationBuilder(assembly));
         }
 
-        private IConfigurationBuilder GetBaseConfigurationBuilder(Assembly assembly)
+        private IConfigurationBuilder CreateBaseConfigurationBuilder(Assembly assembly)
         {
             var basePath = Path.GetDirectoryName(assembly.Location)
                            ?? throw new InvalidOperationException(
@@ -80,10 +79,12 @@
                 .AddEnvironmentJsonFile(basePath, configFile);
         }
 
-        private void AddUserConfigurations(IConfigurationBuilder configurationBuilder)
+        private void AddUserConfigurations(Func<IConfigurationBuilder> builderFactory)
         {
             Services.AddSingleton<IConfiguration>(sp =>
             {
+                var configurationBuilder = builderFactory();
+
                 foreach (var addConfig in sp.GetServices<Action<IServiceProvider, IConfigurationBuilder>>())
                     addConfig(sp, configurationBuilder);
 

--- a/src/Revit/RxBim.Application.Ribbon.Revit/Extensions/ContainerExtensions.cs
+++ b/src/Revit/RxBim.Application.Ribbon.Revit/Extensions/ContainerExtensions.cs
@@ -31,6 +31,23 @@ namespace RxBim.Application.Ribbon
         }
 
         /// <summary>
+        /// Adds ribbon menu from action.
+        /// </summary>
+        /// <param name="services">DI container.</param>
+        /// <param name="builder">The ribbon builder.</param>
+        /// <param name="menuAssembly">Menu assembly.</param>
+        public static void AddRevitMenu(
+            this IServiceCollection services,
+            Action<IServiceProvider, IRibbonBuilder> builder,
+            Assembly? menuAssembly = null)
+        {
+            menuAssembly ??= Assembly.GetCallingAssembly();
+            services
+                .AddServices()
+                .AddMenu<RevitRibbonMenuBuilder>(builder, menuAssembly);
+        }
+
+        /// <summary>
         /// Adds ribbon menu from config.
         /// </summary>
         /// <param name="services">DI container.</param>


### PR DESCRIPTION
Исправление ошибки: при повторном создании контейнера, конфигурация "наследовала" поставщиков от предыдущих контейнеров.
Добавлены расширения Add*Menu принимающие делегат Action<IServiceProvider, IRibbonBuilder>, для настройки ленты с использованием IServiceProvider.