### PR TITLE
ConfigureBuildSettings

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -20,6 +20,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="NuGet.Frameworks" Version="7.9.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -29,7 +30,7 @@
         <!-- Common build related files -->
 
         <None Include="..\.nuke" LinkBase="config" />
-        
+
         <None Include="..\build.sh" LinkBase="scripts" />
         <None Include="..\build.ps1" LinkBase="scripts" />
 

--- a/src/Core/RxBim.Nuke/Builds/RxBimBuild.Common.cs
+++ b/src/Core/RxBim.Nuke/Builds/RxBimBuild.Common.cs
@@ -50,9 +50,9 @@
         /// <inheritdoc cref="Compile"/>
         protected virtual void CompileInternal()
         {
-            DotNetBuild(settings => settings
+            DotNetBuild(settings => ConfigureBuildSettings(settings
                 .SetProjectFile(Solution.Path)
-                .SetConfiguration(Configuration));
+                .SetConfiguration(Configuration)));
         }
 
         /// <inheritdoc cref="Restore"/>

--- a/src/Core/RxBim.Nuke/Builds/RxBimBuild.Common.cs
+++ b/src/Core/RxBim.Nuke/Builds/RxBimBuild.Common.cs
@@ -3,7 +3,9 @@
     using System.Linq;
     using global::Nuke.Common;
     using global::Nuke.Common.IO;
+    using global::Nuke.Common.Tooling;
     using global::Nuke.Common.Tools.DotNet;
+    using global::Nuke.Common.Utilities;
     using global::Nuke.Common.Utilities.Collections;
     using static global::Nuke.Common.Tools.DotNet.DotNetTasks;
 
@@ -50,9 +52,10 @@
         /// <inheritdoc cref="Compile"/>
         protected virtual void CompileInternal()
         {
-            DotNetBuild(settings => ConfigureBuildSettings(settings
+            DotNetBuild(settings => settings
                 .SetProjectFile(Solution.Path)
-                .SetConfiguration(Configuration)));
+                .SetConfiguration(Configuration)
+                .Apply(CompileSettings));
         }
 
         /// <inheritdoc cref="Restore"/>

--- a/src/Core/RxBim.Nuke/Builds/RxBimBuild.cs
+++ b/src/Core/RxBim.Nuke/Builds/RxBimBuild.cs
@@ -10,7 +10,9 @@
     using global::Nuke.Common;
     using global::Nuke.Common.IO;
     using global::Nuke.Common.ProjectModel;
+    using global::Nuke.Common.Tooling;
     using global::Nuke.Common.Tools.DotNet;
+    using global::Nuke.Common.Utilities;
     using Helpers;
     using JetBrains.Annotations;
     using Models;
@@ -80,10 +82,11 @@
             .DependsOn(Restore)
             .Executes(() =>
             {
-                DotNetBuild(settings => ConfigureBuildSettings(settings
+                DotNetBuild(settings => settings
                     .SetProjectFile(GetProjectPath(Project))
                     .SetOutputDirectory(OutputTmpDirBin)
-                    .SetConfiguration(Configuration)));
+                    .SetConfiguration(Configuration)
+                    .Apply(CompileSettings));
             });
 
         /// <summary>
@@ -167,14 +170,9 @@
             });
 
         /// <summary>
-        /// Configures additional project build settings.
+        /// Gets additional project build settings.
         /// </summary>
-        /// <param name="settings">The dotnet build settings.</param>
-        /// <returns>The configured dotnet build settings.</returns>
-        protected virtual DotNetBuildSettings ConfigureBuildSettings(DotNetBuildSettings settings)
-        {
-            return settings;
-        }
+        protected virtual Configure<DotNetBuildSettings> CompileSettings => _ => _;
 
         /// <summary>
         /// Configures the installer builder before generating additional files.

--- a/src/Core/RxBim.Nuke/Builds/RxBimBuild.cs
+++ b/src/Core/RxBim.Nuke/Builds/RxBimBuild.cs
@@ -80,10 +80,10 @@
             .DependsOn(Restore)
             .Executes(() =>
             {
-                DotNetBuild(settings => settings
+                DotNetBuild(settings => ConfigureBuildSettings(settings
                     .SetProjectFile(GetProjectPath(Project))
                     .SetOutputDirectory(OutputTmpDirBin)
-                    .SetConfiguration(Configuration));
+                    .SetConfiguration(Configuration)));
             });
 
         /// <summary>
@@ -165,6 +165,16 @@
                     OutputTmpDir,
                     SeriesMaxAny);
             });
+
+        /// <summary>
+        /// Configures additional project build settings.
+        /// </summary>
+        /// <param name="settings">The dotnet build settings.</param>
+        /// <returns>The configured dotnet build settings.</returns>
+        protected virtual DotNetBuildSettings ConfigureBuildSettings(DotNetBuildSettings settings)
+        {
+            return settings;
+        }
 
         /// <summary>
         /// Configures the installer builder before generating additional files.


### PR DESCRIPTION
Возможность задавать параметры сборки DotNetBuildSettings в клиентских приложениях.

Например, в Инспекторе переопределяют CompileToTemp и CompileToVersionTemp для установки своего PublicationMode:
DotNetBuildSettings.AddProcessEnvironmentVariable("PublicationMode") PIK или Demo.