### PR TITLE
ReuseSeparatedContext - один контекст на приложение.

### DIFF
--- a/RxBim.slnx
+++ b/RxBim.slnx
@@ -64,6 +64,7 @@
     <Project Path="src/Revit/RxBim.Nuke.Revit/RxBim.Nuke.Revit.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/RxBim.Shared.Tests/RxBim.Shared.Tests.csproj" />
     <Project Path="tests/RxBim.Analyzers.Tests/RxBim.Analyzers.Tests.csproj" />
     <Project Path="tests/RxBim.Application.Ribbon.Tests/RxBim.Application.Ribbon.Tests.csproj" />
     <Project Path="tests/RxBim.Di.Tests/RxBim.Di.Tests.csproj" />

--- a/RxBim.slnx
+++ b/RxBim.slnx
@@ -74,6 +74,7 @@
     <Project Path="tests/RxBim.Shared.Tests/Fixtures/Dependency/RxBim.Shared.Tests.Dependency.csproj" />
     <Project Path="tests/RxBim.Shared.Tests/Fixtures/First/RxBim.Shared.Tests.First.csproj" />
     <Project Path="tests/RxBim.Shared.Tests/Fixtures/Second/RxBim.Shared.Tests.Second.csproj" />
+    <Project Path="tests/RxBim.Shared.Tests/Fixtures/WpfProbe/RxBim.Shared.Tests.WpfProbe.csproj" />
   </Folder>
   <Project Path="build/_build.csproj">
     <Build Project="false" />

--- a/RxBim.slnx
+++ b/RxBim.slnx
@@ -70,6 +70,11 @@
     <Project Path="tests/RxBim.Di.Tests/RxBim.Di.Tests.csproj" />
     <Project Path="tests/RxBim.Nuke.Tests/RxBim.Nuke.Tests.csproj" />
   </Folder>
+  <Folder Name="/tests/Fixtures/">
+    <Project Path="tests/RxBim.Shared.Tests/Fixtures/Dependency/RxBim.Shared.Tests.Dependency.csproj" />
+    <Project Path="tests/RxBim.Shared.Tests/Fixtures/First/RxBim.Shared.Tests.First.csproj" />
+    <Project Path="tests/RxBim.Shared.Tests/Fixtures/Second/RxBim.Shared.Tests.Second.csproj" />
+  </Folder>
   <Project Path="build/_build.csproj">
     <Build Project="false" />
   </Project>

--- a/Samples/Autocad/RxBim.Sample.Application.Menu.Fluent.Autocad/App.cs
+++ b/Samples/Autocad/RxBim.Sample.Application.Menu.Fluent.Autocad/App.cs
@@ -12,6 +12,14 @@ namespace RxBim.Sample.Application.Menu.Fluent.Autocad
     /// <inheritdoc />
     public class App : RxBimApplication
     {
+#if NETCOREAPP
+        /// <inheritdoc />
+        protected override bool RunInSeparatedContext => true;
+
+        /// <inheritdoc />
+        protected override bool ReuseSeparatedContext => true;
+#endif
+
         /// <summary>
         /// Start application.
         /// </summary>

--- a/Samples/Autocad/RxBim.Sample.Application.Menu.Fluent.Autocad/Commands/Cmd1.cs
+++ b/Samples/Autocad/RxBim.Sample.Application.Menu.Fluent.Autocad/Commands/Cmd1.cs
@@ -18,6 +18,14 @@
         HelpUrl = "https://github.com/ReactiveBIM/RxBim")]
     public class Cmd1 : RxBimCommand
     {
+#if NETCOREAPP
+        /// <inheritdoc />
+        protected override bool RunInSeparatedContext => true;
+
+        /// <inheritdoc />
+        protected override bool ReuseSeparatedContext => true;
+#endif
+
         /// <summary>
         /// Executes the command.
         /// </summary>

--- a/Samples/Autocad/RxBim.Sample.Application.Menu.Fluent.Autocad/Commands/Cmd2.cs
+++ b/Samples/Autocad/RxBim.Sample.Application.Menu.Fluent.Autocad/Commands/Cmd2.cs
@@ -17,6 +17,14 @@
         HelpUrl = "https://www.google.com/")]
     public class Cmd2 : RxBimCommand
     {
+#if NETCOREAPP
+        /// <inheritdoc />
+        protected override bool RunInSeparatedContext => true;
+
+        /// <inheritdoc />
+        protected override bool ReuseSeparatedContext => true;
+#endif
+
         /// <summary>
         /// Command execution.
         /// </summary>

--- a/Samples/Autocad/RxBim.Sample.Application.Menu.Fluent.Autocad/Commands/Cmd3.cs
+++ b/Samples/Autocad/RxBim.Sample.Application.Menu.Fluent.Autocad/Commands/Cmd3.cs
@@ -17,6 +17,14 @@
         HelpUrl = "https://www.autodesk.com/")]
     public class Cmd3 : RxBimCommand
     {
+#if NETCOREAPP
+        /// <inheritdoc />
+        protected override bool RunInSeparatedContext => true;
+
+        /// <inheritdoc />
+        protected override bool ReuseSeparatedContext => true;
+#endif
+
         /// <summary>
         /// Command execution.
         /// </summary>

--- a/Samples/Revit/RxBim.Sample.Application.Menu.Fluent.Revit/App.cs
+++ b/Samples/Revit/RxBim.Sample.Application.Menu.Fluent.Revit/App.cs
@@ -9,6 +9,14 @@
     /// <inheritdoc />
     public class App : RxBimApplication
     {
+#if NETCOREAPP
+        /// <inheritdoc />
+        protected override bool RunInSeparatedContext => true;
+
+        /// <inheritdoc />
+        protected override bool ReuseSeparatedContext => true;
+#endif
+
         /// <summary>
         /// Start application.
         /// </summary>

--- a/Samples/Revit/RxBim.Sample.Application.Menu.Fluent.Revit/Cmd1.cs
+++ b/Samples/Revit/RxBim.Sample.Application.Menu.Fluent.Revit/Cmd1.cs
@@ -21,6 +21,14 @@
         HelpUrl = "https://github.com/ReactiveBIM/RxBim")]
     public class Cmd1 : RxBimCommand
     {
+#if NETCOREAPP
+        /// <inheritdoc />
+        protected override bool RunInSeparatedContext => true;
+
+        /// <inheritdoc />
+        protected override bool ReuseSeparatedContext => true;
+#endif
+
         /// <summary>
         /// cmd.
         /// </summary>

--- a/Samples/Revit/RxBim.Sample.Application.Menu.Fluent.Revit/Cmd2.cs
+++ b/Samples/Revit/RxBim.Sample.Application.Menu.Fluent.Revit/Cmd2.cs
@@ -19,6 +19,14 @@
         HelpUrl = "https://www.google.com/")]
     public class Cmd2 : RxBimCommand
     {
+#if NETCOREAPP
+        /// <inheritdoc />
+        protected override bool RunInSeparatedContext => true;
+
+        /// <inheritdoc />
+        protected override bool ReuseSeparatedContext => true;
+#endif
+
         /// <summary>
         /// cmd.
         /// </summary>

--- a/Samples/Revit/RxBim.Sample.Application.Menu.Fluent.Revit/Cmd3.cs
+++ b/Samples/Revit/RxBim.Sample.Application.Menu.Fluent.Revit/Cmd3.cs
@@ -19,6 +19,14 @@
         HelpUrl = "https://www.autodesk.com/")]
     public class Cmd3 : RxBimCommand
     {
+#if NETCOREAPP
+        /// <inheritdoc />
+        protected override bool RunInSeparatedContext => true;
+
+        /// <inheritdoc />
+        protected override bool ReuseSeparatedContext => true;
+#endif
+
         /// <summary>
         /// cmd.
         /// </summary>

--- a/src/Autocad/RxBim.Application.Autocad/RxBimApplication.cs
+++ b/src/Autocad/RxBim.Application.Autocad/RxBimApplication.cs
@@ -23,6 +23,13 @@ namespace RxBim.Application.Autocad
         /// via Addin Manager.
         /// </summary>
         protected virtual bool RunInSeparatedContext => false;
+
+        /// <summary>
+        /// Reuses the context for the application's DLL directory until AutoCAD exits.
+        /// Applies only when <see cref="RunInSeparatedContext"/> is enabled.
+        /// Enable this setting for the application's commands as well to share the same context.
+        /// </summary>
+        protected virtual bool ReuseSeparatedContext => false;
 #endif
 
         /// <inheritdoc />
@@ -34,6 +41,12 @@ namespace RxBim.Application.Autocad
                 var type = GetType();
                 if (!PluginContext.IsCurrentContextRxBim(type))
                 {
+                    if (ReuseSeparatedContext)
+                    {
+                        InitializeInReusedContext(type);
+                        return;
+                    }
+
                     var appInstance = PluginContext.CreateInstanceInNewContext(type);
                     if (appInstance is IExtensionApplication application)
                     {
@@ -66,6 +79,26 @@ namespace RxBim.Application.Autocad
         /// If it returns true, the application will run. Otherwise, the application will not run.
         /// </summary>
         protected virtual bool CanBeStarted() => true;
+
+#if NETCOREAPP
+        private void InitializeInReusedContext(Type type)
+        {
+            IExtensionApplication application;
+
+            try
+            {
+                application = (IExtensionApplication)PluginContext.CreateInstanceInReusedContext(type);
+            }
+            catch (Exception exception)
+            {
+                // Report loading failures without initializing in the original context.
+                Application.ShowAlertDialog($"Error: {exception}");
+                return;
+            }
+
+            application.Initialize();
+        }
+#endif
 
         private void ApplicationOnIdle(object? sender, EventArgs e)
         {

--- a/src/Autocad/RxBim.Command.Autocad/RxBimCommand.cs
+++ b/src/Autocad/RxBim.Command.Autocad/RxBimCommand.cs
@@ -16,6 +16,13 @@
         /// Allows you to turn off plugin execution in separated context.
         /// </summary>
         protected virtual bool RunInSeparatedContext => false;
+
+        /// <summary>
+        /// Reuses the context for the application's DLL directory until AutoCAD exits.
+        /// Applies only when <see cref="RunInSeparatedContext"/> is enabled.
+        /// A new command instance and DI container are created for each execution.
+        /// </summary>
+        protected virtual bool ReuseSeparatedContext => false;
 #endif
 
         /// <summary>
@@ -28,6 +35,12 @@
 #if NETCOREAPP
             if (RunInSeparatedContext && !PluginContext.IsCurrentContextRxBim(type))
             {
+                if (ReuseSeparatedContext)
+                {
+                    ExecuteInReusedContext(type);
+                    return;
+                }
+
                 var newInstance = PluginContext.CreateInstanceInNewContext(type);
                 if (newInstance is RxBimCommand rxBimCommand)
                 {
@@ -39,6 +52,28 @@
 
             CallCommandMethod(assembly);
         }
+
+#if NETCOREAPP
+        private void ExecuteInReusedContext(Type type)
+        {
+            Action execute;
+
+            try
+            {
+                var command = PluginContext.CreateInstanceInReusedContext(type);
+
+                // The command's base type may belong to another context; Action is shared by the runtime.
+                execute = (Action)Delegate.CreateDelegate(typeof(Action), command, nameof(Execute));
+            }
+            catch (Exception exception)
+            {
+                Autodesk.AutoCAD.ApplicationServices.Core.Application.ShowAlertDialog($"Error: {exception}");
+                return;
+            }
+
+            execute();
+        }
+#endif
 
         private IServiceProvider Configure(Assembly assembly)
         {

--- a/src/Core/RxBim.Shared/PluginContext.cs
+++ b/src/Core/RxBim.Shared/PluginContext.cs
@@ -2,19 +2,18 @@
 namespace RxBim.Shared;
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Threading;
 
 /// <inheritdoc />
 public class PluginContext : AssemblyLoadContext
 {
     private const string ContextNamePrefix = "RxBim:";
     private const string AssemblyExtension = ".dll";
-    private static readonly ConcurrentDictionary<string, Lazy<PluginContext>> ReusedContexts =
+    private static readonly Dictionary<string, PluginContext> ReusedContexts =
         new(StringComparer.OrdinalIgnoreCase);
     private readonly AssemblyDependencyResolver _resolver;
     private readonly string? _directory;
@@ -99,10 +98,11 @@ public class PluginContext : AssemblyLoadContext
         assemblyPath = Path.GetFullPath(assemblyPath);
         var directory = Path.TrimEndingDirectorySeparator(Path.GetDirectoryName(assemblyPath)!);
 
-        // Lazy prevents concurrent calls from creating redundant non-collectible contexts.
-        var context = ReusedContexts.GetOrAdd(directory, _ => new Lazy<PluginContext>(
-            () => new PluginContext(assemblyPath),
-            LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+        if (!ReusedContexts.TryGetValue(directory, out var context))
+        {
+            context = new PluginContext(assemblyPath);
+            ReusedContexts.Add(directory, context);
+        }
 
         return context.CreateInstanceCore(type);
     }

--- a/src/Core/RxBim.Shared/PluginContext.cs
+++ b/src/Core/RxBim.Shared/PluginContext.cs
@@ -2,16 +2,22 @@
 namespace RxBim.Shared;
 
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Threading;
 
 /// <inheritdoc />
 public class PluginContext : AssemblyLoadContext
 {
     private const string ContextNamePrefix = "RxBim:";
+    private const string AssemblyExtension = ".dll";
+    private static readonly ConcurrentDictionary<string, Lazy<PluginContext>> ReusedContexts =
+        new(StringComparer.OrdinalIgnoreCase);
     private readonly AssemblyDependencyResolver _resolver;
+    private readonly string? _directory;
 
     /// <summary>
     /// ctor.
@@ -22,6 +28,13 @@ public class PluginContext : AssemblyLoadContext
      : base($"{ContextNamePrefix}{pluginName}")
     {
         _resolver = new AssemblyDependencyResolver(assemblyPath);
+    }
+
+    private PluginContext(string assemblyPath)
+        : this(assemblyPath, Path.GetDirectoryName(assemblyPath)!)
+    {
+        // Reused contexts also search the directory for other commands' dependencies.
+        _directory = Path.GetDirectoryName(assemblyPath);
     }
 
     /// <summary>
@@ -66,6 +79,35 @@ public class PluginContext : AssemblyLoadContext
     }
 
     /// <summary>
+    /// Creates a new object in the application directory's shared context, retained until the process exits.
+    /// </summary>
+    /// <param name="type">The type to instantiate from an application assembly.</param>
+    /// <remarks>
+    /// Loading and constructor errors propagate to the caller without removing the context from the registry.
+    /// Dependencies are resolved using the first assembly's manifest, then the application directory.
+    /// Application assemblies must reside in the same directory.
+    /// Updating DLLs requires restarting the host.
+    /// </remarks>
+    public static object CreateInstanceInReusedContext(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        var assemblyPath = type.Assembly.Location;
+
+        if (string.IsNullOrEmpty(assemblyPath))
+            throw new ArgumentException("A reused context requires an assembly with a DLL path.", nameof(type));
+
+        assemblyPath = Path.GetFullPath(assemblyPath);
+        var directory = Path.TrimEndingDirectorySeparator(Path.GetDirectoryName(assemblyPath)!);
+
+        // Lazy prevents concurrent calls from creating redundant non-collectible contexts.
+        var context = ReusedContexts.GetOrAdd(directory, _ => new Lazy<PluginContext>(
+            () => new PluginContext(assemblyPath),
+            LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+
+        return context.CreateInstanceCore(type);
+    }
+
+    /// <summary>
     /// Creates instance of specified type in current context;
     /// </summary>
     /// <param name="type">Type.</param>
@@ -73,10 +115,7 @@ public class PluginContext : AssemblyLoadContext
     {
         try
         {
-            var assembly = type.Assembly;
-            var location = assembly.Location;
-            var loadedAssembly = LoadFromAssemblyPath(location);
-            return loadedAssembly.CreateInstance(type.FullName!);
+            return CreateInstanceCore(type);
         }
         catch
         {
@@ -88,6 +127,10 @@ public class PluginContext : AssemblyLoadContext
     protected override Assembly? Load(AssemblyName assemblyName)
     {
         var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+
+        if (assemblyPath is null && _directory is not null)
+            assemblyPath = GetLocalAssemblyPath(assemblyName);
+
         if (assemblyPath is null)
             return null;
 
@@ -99,6 +142,28 @@ public class PluginContext : AssemblyLoadContext
         }
 
         return LoadFromAssemblyPath(assemblyPath);
+    }
+
+    private string? GetLocalAssemblyPath(AssemblyName assemblyName)
+    {
+        var name = assemblyName.Name;
+        var culture = assemblyName.CultureName;
+
+        if (string.IsNullOrEmpty(name) || Path.GetFileName(name) != name
+            || (!string.IsNullOrEmpty(culture) && Path.GetFileName(culture) != culture))
+            return null;
+
+        var directory = string.IsNullOrEmpty(culture) ? _directory! : Path.Combine(_directory!, culture);
+        var path = Path.Combine(directory, name + AssemblyExtension);
+
+        return File.Exists(path) ? path : null;
+    }
+
+    private object CreateInstanceCore(Type type)
+    {
+        var loadedAssembly = LoadFromAssemblyPath(type.Assembly.Location);
+        return loadedAssembly.CreateInstance(type.FullName!)
+               ?? throw new TypeLoadException($"Could not instantiate type '{type.FullName}' from '{loadedAssembly.Location}'.");
     }
 }
 #endif

--- a/src/Revit/RxBim.Application.Revit/RxBimApplication.cs
+++ b/src/Revit/RxBim.Application.Revit/RxBimApplication.cs
@@ -3,7 +3,6 @@
     using System;
     using Autodesk.Revit.UI;
     using Autodesk.Revit.UI.Events;
-    using Di;
     using Microsoft.Extensions.DependencyInjection;
     using Ribbon;
     using Shared;
@@ -28,6 +27,13 @@
         /// is preferred to avoid nesting it inside Revit's isolated context.
         /// </summary>
         protected virtual bool RunInSeparatedContext => false;
+
+        /// <summary>
+        /// Reuses the context for the application's DLL directory until Revit exits.
+        /// Applies only when <see cref="RunInSeparatedContext"/> is enabled.
+        /// Enable this setting for the application's commands as well to share the same context.
+        /// </summary>
+        protected virtual bool ReuseSeparatedContext => false;
 #endif
 
         /// <inheritdoc />
@@ -39,11 +45,12 @@
                 var type = GetType();
                 if (!PluginContext.IsCurrentContextRxBim(type))
                 {
+                    if (ReuseSeparatedContext)
+                        return StartInReusedContext(type, application);
+
                     _isolatedApplicationInstance = PluginContext.CreateInstanceInNewContext(type);
                     if (_isolatedApplicationInstance is IExternalApplication app)
-                    {
                         return app.OnStartup(application);
-                    }
                 }
             }
 #endif
@@ -72,6 +79,27 @@
 
             return ShutdownApplication();
         }
+
+#if NETCOREAPP
+        private Result StartInReusedContext(Type type, UIControlledApplication application)
+        {
+            IExternalApplication app;
+
+            try
+            {
+                app = (IExternalApplication)PluginContext.CreateInstanceInReusedContext(type);
+            }
+            catch (Exception exception)
+            {
+                // Report loading failures instead of starting the application without the requested isolation.
+                TaskDialog.Show(nameof(RxBim), exception.ToString());
+                return Result.Failed;
+            }
+
+            _isolatedApplicationInstance = app;
+            return app.OnStartup(application);
+        }
+#endif
 
         private Result ExecuteApplication(UIControlledApplication application)
         {

--- a/src/Revit/RxBim.Command.Revit/RxBimCommand.cs
+++ b/src/Revit/RxBim.Command.Revit/RxBimCommand.cs
@@ -26,6 +26,13 @@
         /// is preferred to avoid nesting it inside Revit's isolated context.
         /// </summary>
         protected virtual bool RunInSeparatedContext => false;
+
+        /// <summary>
+        /// Reuses the context for the application's DLL directory until Revit exits.
+        /// Applies only when <see cref="RunInSeparatedContext"/> is enabled.
+        /// A new command instance and DI container are created for each execution.
+        /// </summary>
+        protected virtual bool ReuseSeparatedContext => false;
 #endif
 
         /// <inheritdoc />
@@ -40,6 +47,9 @@
 #if NETCOREAPP
             if (PluginContext.IsCurrentContextRxBim(type) || !RunInSeparatedContext)
                 return ExecuteCommand(commandData, ref message, elements, assembly);
+
+            if (ReuseSeparatedContext)
+                return ExecuteInReusedContext(type, commandData, ref message, elements);
 
             var commandInstance = PluginContext.CreateInstanceInNewContext(type);
             if (commandInstance is IExternalCommand externalCommand)
@@ -56,6 +66,26 @@
         {
             return applicationData.ActiveUIDocument?.Document != null;
         }
+
+#if NETCOREAPP
+        private Result ExecuteInReusedContext(Type type, ExternalCommandData commandData, ref string? message, ElementSet elements)
+        {
+            IExternalCommand command;
+
+            try
+            {
+                command = (IExternalCommand)PluginContext.CreateInstanceInReusedContext(type);
+            }
+            catch (Exception exception)
+            {
+                // A reused context failure must not cause the command to run in the original context.
+                message = exception.ToString();
+                return Result.Failed;
+            }
+
+            return command.Execute(commandData, ref message, elements);
+        }
+#endif
 
         private Result ExecuteCommand(ExternalCommandData commandData, ref string? message, ElementSet elements, Assembly assembly)
         {

--- a/tests/RxBim.Shared.Tests/AssemblyInfo.cs
+++ b/tests/RxBim.Shared.Tests/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+﻿// PluginContext's shared registry requires sequential access, including across test classes.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/RxBim.Shared.Tests/AutocadCommandContextTests.cs
+++ b/tests/RxBim.Shared.Tests/AutocadCommandContextTests.cs
@@ -1,0 +1,65 @@
+﻿namespace RxBim.Shared.Tests;
+
+using System;
+using Xunit;
+using static TestPluginDirectory;
+
+public class AutocadCommandContextTests
+{
+    [Fact]
+    public void IsolationAndReuseRemainDisabledByDefault()
+    {
+        using var directory = new TestPluginDirectory();
+        var type = directory.LoadType(FirstAssemblyName, "DefaultAutocadCommand");
+        var command = Activator.CreateInstance(type)!;
+
+        Assert.False(ReadProperty<bool>(command, "DefaultRunInSeparatedContext"));
+        Assert.False(ReadProperty<bool>(command, "DefaultReuseSeparatedContext"));
+    }
+
+    [Fact]
+    public void CommandsExecuteInTheReusedContextDespiteDifferentBaseTypeIdentity()
+    {
+        using var directory = new TestPluginDirectory();
+        var type = directory.LoadType(FirstAssemblyName, "ReusedAutocadCommand");
+        var sourceCommand = Activator.CreateInstance(type)!;
+
+        Execute(sourceCommand);
+        Execute(Activator.CreateInstance(type)!);
+
+        var isolatedCommand = PluginContext.CreateInstanceInReusedContext(type);
+        Assert.False(type.BaseType!.IsInstanceOfType(isolatedCommand));
+        Assert.Equal(0, ReadProperty<int>(sourceCommand, "ExecutionCount"));
+        Assert.Equal(2, ReadProperty<int>(isolatedCommand, "ExecutionCount"));
+        Assert.Empty(ReadProperty<string>(sourceCommand, "LastError"));
+    }
+
+    [Fact]
+    public void ActivationFailureReportsTheErrorWithoutExecutingInTheOriginalContext()
+    {
+        using var directory = new TestPluginDirectory();
+        var type = directory.LoadType(FirstAssemblyName, "FailingAutocadCommand");
+        var command = Activator.CreateInstance(type)!;
+
+        Execute(command);
+
+        Assert.Equal(0, ReadProperty<int>(command, "ExecutionCount"));
+        Assert.Contains("Isolated activation failed.", ReadProperty<string>(command, "LastError"));
+    }
+
+    [Fact]
+    public void ExecutionFailurePropagatesWithoutBeingReportedAsAnActivationError()
+    {
+        using var directory = new TestPluginDirectory();
+        var type = directory.LoadType(FirstAssemblyName, "ThrowingAutocadCommand");
+        var command = Activator.CreateInstance(type)!;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => Execute(command));
+
+        Assert.Equal("Command execution failed.", exception.Message);
+        Assert.Empty(ReadProperty<string>(command, "LastError"));
+    }
+
+    private static void Execute(object command) =>
+        ((Action)Delegate.CreateDelegate(typeof(Action), command, "Execute"))();
+}

--- a/tests/RxBim.Shared.Tests/ContextConflictTests.cs
+++ b/tests/RxBim.Shared.Tests/ContextConflictTests.cs
@@ -1,0 +1,42 @@
+﻿namespace RxBim.Shared.Tests;
+
+using System;
+using System.Reflection;
+using Xunit;
+using static TestPluginDirectory;
+
+public class ContextConflictTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ModelRetainedFromPreviousCommandCanOnlyBeCastInTheSameContext(bool reuse)
+    {
+        using var directory = new TestPluginDirectory();
+        var type = directory.LoadType(FirstAssemblyName, "WpfPlugin");
+        var first = Create(type, reuse);
+        var second = Create(type, reuse);
+        var firstModelType = ReadProperty<Type>(first, "ModelType");
+        var secondModelType = ReadProperty<Type>(second, "ModelType");
+        var retainedModel = Activator.CreateInstance(firstModelType)!;
+        var cast = second.GetType().GetMethod("CastModel")!;
+
+        // Identical names do not imply compatible runtime types.
+        Assert.Equal(firstModelType.AssemblyQualifiedName, secondModelType.AssemblyQualifiedName);
+        Assert.Equal(reuse, secondModelType.IsInstanceOfType(retainedModel));
+
+        if (reuse)
+        {
+            Assert.Same(retainedModel, cast.Invoke(second, [retainedModel]));
+        }
+        else
+        {
+            var exception = Assert.Throws<TargetInvocationException>(() => cast.Invoke(second, [retainedModel]));
+            Assert.IsType<InvalidCastException>(exception.InnerException);
+        }
+    }
+
+    private static object Create(Type type, bool reuse) => reuse
+        ? PluginContext.CreateInstanceInReusedContext(type)
+        : PluginContext.CreateInstanceInNewContext(type)!;
+}

--- a/tests/RxBim.Shared.Tests/Fixtures/Dependency/Counter.cs
+++ b/tests/RxBim.Shared.Tests/Fixtures/Dependency/Counter.cs
@@ -1,0 +1,16 @@
+﻿namespace RxBim.Shared.Tests.Dependency;
+
+using System.Threading;
+
+/// <summary>
+/// Shared state for test plugins within a single context.
+/// </summary>
+public static class Counter
+{
+    private static int _value;
+
+    /// <summary>
+    /// Increments the count of created objects.
+    /// </summary>
+    public static int Next() => Interlocked.Increment(ref _value);
+}

--- a/tests/RxBim.Shared.Tests/Fixtures/Dependency/RxBim.Shared.Tests.Dependency.csproj
+++ b/tests/RxBim.Shared.Tests/Fixtures/Dependency/RxBim.Shared.Tests.Dependency.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDependencyFile>true</GenerateDependencyFile>
+  </PropertyGroup>
+</Project>

--- a/tests/RxBim.Shared.Tests/Fixtures/Dependency/ViewModel.cs
+++ b/tests/RxBim.Shared.Tests/Fixtures/Dependency/ViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Markup;
+
+[assembly: XmlnsDefinition("urn:rxbim:context-tests", "RxBim.Shared.Tests.Dependency")]
+
+namespace RxBim.Shared.Tests.Dependency;
+
+/// <summary>
+/// A private type used by both C# and XAML.
+/// </summary>
+public sealed class ViewModel
+{
+}

--- a/tests/RxBim.Shared.Tests/Fixtures/First/AutocadHostStubs.cs
+++ b/tests/RxBim.Shared.Tests/Fixtures/First/AutocadHostStubs.cs
@@ -1,0 +1,37 @@
+﻿// These substitutes must never be used to execute a command's host-dependent DI path.
+namespace RxBim.Di
+{
+    using System;
+    using System.Reflection;
+
+    internal sealed class CommandDiConfigurator
+    {
+        public CommandDiConfigurator(object command) =>
+            throw new InvalidOperationException("Unexpected execution in the original context.");
+
+        public void Configure(Assembly assembly) => throw new NotSupportedException();
+
+        public IServiceProvider Build() => throw new NotSupportedException();
+    }
+}
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    using System;
+
+    internal static class ServiceProviderServiceExtensions
+    {
+        public static T GetRequiredService<T>(this IServiceProvider provider) =>
+            throw new NotSupportedException();
+    }
+}
+
+namespace Autodesk.AutoCAD.ApplicationServices.Core
+{
+    internal static class Application
+    {
+        public static string LastAlert { get; private set; } = string.Empty;
+
+        public static void ShowAlertDialog(string message) => LastAlert = message;
+    }
+}

--- a/tests/RxBim.Shared.Tests/Fixtures/First/FailOncePlugin.cs
+++ b/tests/RxBim.Shared.Tests/Fixtures/First/FailOncePlugin.cs
@@ -1,0 +1,21 @@
+﻿namespace RxBim.Shared.Tests.First;
+
+using System;
+using System.Threading;
+
+/// <summary>
+/// Verifies that the context is retained after a constructor failure.
+/// </summary>
+public sealed class FailOncePlugin
+{
+    private static int _attempts;
+
+    /// <summary>
+    /// Fails on the first constructor call and creates an object on subsequent calls.
+    /// </summary>
+    public FailOncePlugin()
+    {
+        if (Interlocked.Increment(ref _attempts) == 1)
+            throw new InvalidOperationException("The first constructor call failed.");
+    }
+}

--- a/tests/RxBim.Shared.Tests/Fixtures/First/FirstPlugin.cs
+++ b/tests/RxBim.Shared.Tests/Fixtures/First/FirstPlugin.cs
@@ -1,0 +1,30 @@
+﻿namespace RxBim.Shared.Tests.First;
+
+using System;
+using Dependency;
+
+/// <summary>
+/// The first entry point of the test application.
+/// </summary>
+public sealed class FirstPlugin
+{
+    /// <summary>
+    /// The object's sequence number in the application's shared state.
+    /// </summary>
+    public int Sequence { get; } = Counter.Next();
+
+    /// <summary>
+    /// A type from the application's private dependency.
+    /// </summary>
+    public Type DependencyType => typeof(Counter);
+
+    /// <summary>
+    /// A type from the shared infrastructure assembly.
+    /// </summary>
+    public Type InfrastructureType => typeof(PluginContext);
+
+    /// <summary>
+    /// Accesses the registry again from the isolated plugin's code.
+    /// </summary>
+    public object CreateAgain() => PluginContext.CreateInstanceInReusedContext(typeof(FirstPlugin));
+}

--- a/tests/RxBim.Shared.Tests/Fixtures/First/ReusedAutocadCommand.cs
+++ b/tests/RxBim.Shared.Tests/Fixtures/First/ReusedAutocadCommand.cs
@@ -1,0 +1,87 @@
+﻿namespace RxBim.Shared.Tests.First;
+
+using System;
+using RxBim.Command.Autocad;
+using Autodesk.AutoCAD.ApplicationServices.Core;
+
+/// <summary>
+/// Records dispatches through the real AutoCAD command base class in each context.
+/// </summary>
+public class ReusedAutocadCommand : RxBimCommand
+{
+    private static int _executionCount;
+
+    /// <summary>
+    /// The number of invocations in this context.
+    /// </summary>
+    public int ExecutionCount => _executionCount;
+
+    /// <summary>
+    /// The loading error reported by the command base class.
+    /// </summary>
+    public string LastError => Application.LastAlert;
+
+    /// <inheritdoc />
+    protected override bool RunInSeparatedContext => true;
+
+    /// <inheritdoc />
+    protected override bool ReuseSeparatedContext => true;
+
+    /// <inheritdoc />
+    public override void Execute()
+    {
+        if (PluginContext.IsCurrentContextRxBim(GetType()))
+        {
+            _executionCount++;
+            return;
+        }
+
+        base.Execute();
+    }
+}
+
+/// <summary>
+/// Rejects activation only in the isolated context.
+/// </summary>
+public sealed class FailingAutocadCommand : ReusedAutocadCommand
+{
+    /// <summary>
+    /// Creates the source command and rejects its isolated copy.
+    /// </summary>
+    public FailingAutocadCommand()
+    {
+        if (PluginContext.IsCurrentContextRxBim(GetType()))
+            throw new InvalidOperationException("Isolated activation failed.");
+    }
+}
+
+/// <summary>
+/// Fails during execution after successfully entering the isolated context.
+/// </summary>
+public sealed class ThrowingAutocadCommand : ReusedAutocadCommand
+{
+    /// <inheritdoc />
+    public override void Execute()
+    {
+        if (PluginContext.IsCurrentContextRxBim(GetType()))
+            throw new InvalidOperationException("Command execution failed.");
+
+        base.Execute();
+    }
+}
+
+/// <summary>
+/// Exposes the default isolation settings without executing host-dependent code.
+/// </summary>
+public sealed class DefaultAutocadCommand : RxBimCommand
+{
+    /// <summary>
+    /// Whether isolated execution is enabled by default.
+    /// </summary>
+    public bool DefaultRunInSeparatedContext => RunInSeparatedContext;
+
+    /// <summary>
+    /// Whether context reuse is enabled by default.
+    /// </summary>
+    public bool DefaultReuseSeparatedContext => ReuseSeparatedContext;
+}

--- a/tests/RxBim.Shared.Tests/Fixtures/First/RxBim.Shared.Tests.First.csproj
+++ b/tests/RxBim.Shared.Tests/Fixtures/First/RxBim.Shared.Tests.First.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
     <GenerateDependencyFile>true</GenerateDependencyFile>
   </PropertyGroup>

--- a/tests/RxBim.Shared.Tests/Fixtures/First/RxBim.Shared.Tests.First.csproj
+++ b/tests/RxBim.Shared.Tests/Fixtures/First/RxBim.Shared.Tests.First.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDependencyFile>true</GenerateDependencyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Exercise the production dispatch across contexts without requiring a running AutoCAD host. -->
+    <Compile Include="..\..\..\..\src\Autocad\RxBim.Command.Autocad\RxBimCommand.cs" Link="Autocad\RxBimCommand.cs" />
+    <ProjectReference Include="..\Dependency\RxBim.Shared.Tests.Dependency.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Core\RxBim.Shared\RxBim.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/RxBim.Shared.Tests/Fixtures/First/WpfPlugin.cs
+++ b/tests/RxBim.Shared.Tests/Fixtures/First/WpfPlugin.cs
@@ -1,0 +1,49 @@
+﻿namespace RxBim.Shared.Tests.First;
+
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Markup;
+using Dependency;
+
+/// <summary>
+/// Reproduces a template lookup against a private dependency type.
+/// </summary>
+public sealed class WpfPlugin
+{
+    /// <summary>
+    /// The dependency type selected by the executing C# code.
+    /// </summary>
+    public Type ModelType => typeof(ViewModel);
+
+    /// <summary>
+    /// Parses XAML and reports the template type and implicit lookup result.
+    /// </summary>
+    public object[] ReadTemplate()
+    {
+        // Parse directly to isolate type resolution from pack URI resolution of the view assembly.
+        const string xaml = """
+            <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                                xmlns:sample="urn:rxbim:context-tests">
+                <DataTemplate DataType="{x:Type sample:ViewModel}">
+                    <TextBlock Text="Matched template" />
+                </DataTemplate>
+            </ResourceDictionary>
+            """;
+        var view = new ContentControl
+        {
+            Resources = (ResourceDictionary)XamlReader.Parse(xaml),
+            Content = new ViewModel()
+        };
+        var key = view.Resources.Keys.OfType<DataTemplateKey>().Single();
+        return [key.DataType, view.TryFindResource(new DataTemplateKey(view.Content.GetType())) is DataTemplate];
+    }
+
+    /// <summary>
+    /// Casts a model retained by the host from a previous invocation.
+    /// </summary>
+    /// <param name="model">The previously created model.</param>
+    public object CastModel(object model) => (ViewModel)model;
+}

--- a/tests/RxBim.Shared.Tests/Fixtures/Second/RxBim.Shared.Tests.Second.csproj
+++ b/tests/RxBim.Shared.Tests/Fixtures/Second/RxBim.Shared.Tests.Second.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDependencyFile>true</GenerateDependencyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Dependency\RxBim.Shared.Tests.Dependency.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/RxBim.Shared.Tests/Fixtures/Second/SecondPlugin.cs
+++ b/tests/RxBim.Shared.Tests/Fixtures/Second/SecondPlugin.cs
@@ -1,0 +1,20 @@
+﻿namespace RxBim.Shared.Tests.Second;
+
+using System;
+using Dependency;
+
+/// <summary>
+/// The second entry point of the same application, located in a separate DLL.
+/// </summary>
+public sealed class SecondPlugin
+{
+    /// <summary>
+    /// The object's sequence number in the application's shared state.
+    /// </summary>
+    public int Sequence { get; } = Counter.Next();
+
+    /// <summary>
+    /// A type from the application's private dependency.
+    /// </summary>
+    public Type DependencyType => typeof(Counter);
+}

--- a/tests/RxBim.Shared.Tests/Fixtures/WpfProbe/Program.cs
+++ b/tests/RxBim.Shared.Tests/Fixtures/WpfProbe/Program.cs
@@ -1,0 +1,66 @@
+﻿namespace RxBim.Shared.Tests.WpfProbe;
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text.Json;
+
+internal static class Program
+{
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        try
+        {
+            Run(args[0], args[1], bool.Parse(args[2]));
+            return 0;
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(exception);
+            return 1;
+        }
+    }
+
+    private static void Run(string firstDirectory, string secondDirectory, bool reuse)
+    {
+        const string entryName = "RxBim.Shared.Tests.First";
+        const string dependencyName = "RxBim.Shared.Tests.Dependency";
+        var source = new AssemblyLoadContext("Source metadata", isCollectible: true);
+        var type = source.LoadFromAssemblyPath(Path.Combine(firstDirectory, entryName + ".dll"))
+            .GetType(entryName + ".WpfPlugin", throwOnError: true)!;
+        var first = Create(type, reuse);
+        var secondSource = new AssemblyLoadContext("Second source metadata", isCollectible: true);
+        var secondType = secondSource.LoadFromAssemblyPath(Path.Combine(secondDirectory, entryName + ".dll"))
+            .GetType(type.FullName!, throwOnError: true)!;
+        var second = Create(secondType, reuse);
+        var firstModel = (Type)ReadProperty(first, "ModelType");
+        var secondModel = (Type)ReadProperty(second, "ModelType");
+
+        // Model the global host resolver in the linked reproduction: XAML requests
+        // without an addin requester receive the first loaded private dependency.
+        // https://github.com/cunhamauro/XamlParserTypeIdentityMismatch
+        AppDomain.CurrentDomain.AssemblyResolve += (_, request) =>
+            new AssemblyName(request.Name).Name == dependencyName ? firstModel.Assembly : null;
+
+        var firstResult = (object[])first.GetType().GetMethod("ReadTemplate")!.Invoke(first, null)!;
+        var secondResult = (object[])second.GetType().GetMethod("ReadTemplate")!.Invoke(second, null)!;
+        Console.WriteLine(JsonSerializer.Serialize(new
+        {
+            SameModelType = firstModel == secondModel,
+            FirstTemplateMatches = (bool)firstResult[1],
+            SecondTemplateMatches = (bool)secondResult[1],
+            SecondTemplateUsesFirstModel = (Type)secondResult[0] == firstModel,
+            SecondTemplateUsesSecondModel = (Type)secondResult[0] == secondModel
+        }));
+    }
+
+    private static object Create(Type type, bool reuse) => reuse
+        ? PluginContext.CreateInstanceInReusedContext(type)
+        : PluginContext.CreateInstanceInNewContext(type)
+          ?? throw new InvalidOperationException("Could not create the isolated plugin.");
+
+    private static object ReadProperty(object instance, string name) =>
+        instance.GetType().GetProperty(name)!.GetValue(instance)!;
+}

--- a/tests/RxBim.Shared.Tests/Fixtures/WpfProbe/RxBim.Shared.Tests.WpfProbe.csproj
+++ b/tests/RxBim.Shared.Tests/Fixtures/WpfProbe/RxBim.Shared.Tests.WpfProbe.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
-    <GenerateDependencyFile>true</GenerateDependencyFile>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\RxBim.Shared\RxBim.Shared.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/RxBim.Shared.Tests/PluginContextTests.cs
+++ b/tests/RxBim.Shared.Tests/PluginContextTests.cs
@@ -1,0 +1,250 @@
+﻿namespace RxBim.Shared.Tests;
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading.Tasks;
+using Xunit;
+using static TestPluginDirectory;
+
+public class PluginContextTests
+{
+    [Fact]
+    public void NewContextCreatesDifferentTypesAndIndependentState()
+    {
+        using var directory = new TestPluginDirectory();
+        var first = PluginContext.CreateInstanceInNewContext(directory.FirstType)!;
+        var second = PluginContext.CreateInstanceInNewContext(directory.FirstType)!;
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.NotSame(ContextOf(first), ContextOf(second));
+        Assert.NotEqual(first.GetType(), second.GetType());
+        Assert.Equal(1, ReadProperty<int>(first, "Sequence"));
+        Assert.Equal(1, ReadProperty<int>(second, "Sequence"));
+    }
+
+    [Fact]
+    public void ReusedContextCreatesNewObjectsWithTheSameTypeAndSharedState()
+    {
+        using var directory = new TestPluginDirectory();
+        var first = PluginContext.CreateInstanceInReusedContext(directory.FirstType);
+        var second = PluginContext.CreateInstanceInReusedContext(directory.FirstType);
+
+        Assert.NotSame(first, second);
+        Assert.Same(ContextOf(first), ContextOf(second));
+        Assert.Equal(first.GetType(), second.GetType());
+        Assert.Equal(1, ReadProperty<int>(first, "Sequence"));
+        Assert.Equal(2, ReadProperty<int>(second, "Sequence"));
+        Assert.False(ContextOf(first).IsCollectible);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DifferentAssembliesShareTheDirectoryContextInEitherOrder(bool reverse)
+    {
+        using var directory = new TestPluginDirectory();
+        var first = PluginContext.CreateInstanceInReusedContext(reverse ? directory.SecondType : directory.FirstType);
+        var second = PluginContext.CreateInstanceInReusedContext(reverse ? directory.FirstType : directory.SecondType);
+
+        Assert.Same(ContextOf(first), ContextOf(second));
+        Assert.NotSame(first.GetType().Assembly, second.GetType().Assembly);
+        Assert.Same(ReadProperty<Type>(first, "DependencyType"), ReadProperty<Type>(second, "DependencyType"));
+        Assert.Equal(1, ReadProperty<int>(first, "Sequence"));
+        Assert.Equal(2, ReadProperty<int>(second, "Sequence"));
+    }
+
+    [Fact]
+    public void DifferentDirectoriesRemainIsolated()
+    {
+        using var firstDirectory = new TestPluginDirectory();
+        using var secondDirectory = new TestPluginDirectory();
+        var first = PluginContext.CreateInstanceInReusedContext(firstDirectory.FirstType);
+        var second = PluginContext.CreateInstanceInReusedContext(secondDirectory.FirstType);
+
+        Assert.NotSame(ContextOf(first), ContextOf(second));
+        Assert.NotEqual(first.GetType(), second.GetType());
+        Assert.Equal(1, ReadProperty<int>(second, "Sequence"));
+    }
+
+    [Fact]
+    public async Task ConcurrentCallsCreateExactlyOneContext()
+    {
+        const int numberOfCalls = 24;
+        using var directory = new TestPluginDirectory();
+        var type = directory.FirstType;
+        var objects = await Task.WhenAll(Enumerable.Range(0, numberOfCalls)
+            .Select(_ => Task.Run(() => PluginContext.CreateInstanceInReusedContext(type))));
+
+        Assert.Single(objects.Select(ContextOf).Distinct());
+        Assert.Single(AssemblyLoadContext.All.Where(context => context.Name == ContextOf(objects[0]).Name));
+        Assert.Equal(numberOfCalls, objects.Select(instance => ReadProperty<int>(instance, "Sequence")).Distinct().Count());
+    }
+
+    [Fact]
+    public void InfrastructureAndRegistryAreSharedWithTheIsolatedPlugin()
+    {
+        using var directory = new TestPluginDirectory();
+        var first = PluginContext.CreateInstanceInReusedContext(directory.FirstType);
+        var second = first.GetType().GetMethod("CreateAgain")!.Invoke(first, null)!;
+
+        Assert.Same(typeof(PluginContext), ReadProperty<Type>(first, "InfrastructureType"));
+        Assert.Same(ContextOf(first), ContextOf(second));
+        Assert.Equal(2, ReadProperty<int>(second, "Sequence"));
+    }
+
+    [Fact]
+    public void ConstructorFailureDoesNotDiscardTheContext()
+    {
+        using var directory = new TestPluginDirectory();
+        var type = directory.LoadType(FirstAssemblyName, "FailOncePlugin");
+        var exception = Assert.Throws<TargetInvocationException>(() => PluginContext.CreateInstanceInReusedContext(type));
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+
+        var recovered = PluginContext.CreateInstanceInReusedContext(type);
+        var other = PluginContext.CreateInstanceInReusedContext(directory.FirstType);
+        Assert.Same(ContextOf(other), ContextOf(recovered));
+    }
+
+    [Fact]
+    public void LegacyMethodsStillReturnNullOnActivationFailure()
+    {
+        using var directory = new TestPluginDirectory();
+        var type = directory.LoadType(FirstAssemblyName, "FailOncePlugin");
+        Assert.Null(PluginContext.CreateInstanceInNewContext(type));
+        var context = new PluginContext(type.Assembly.Location, "Legacy test");
+        Assert.Null(context.CreateInstanceInContext(type));
+        Assert.NotNull(context.CreateInstanceInContext(type));
+    }
+
+    [Fact]
+    public void ReusedAndNewModesDoNotReuseEachOthersContext()
+    {
+        using var directory = new TestPluginDirectory();
+        var reused = PluginContext.CreateInstanceInReusedContext(directory.FirstType);
+        var fresh = PluginContext.CreateInstanceInNewContext(directory.FirstType)!;
+        Assert.NotSame(ContextOf(reused), ContextOf(fresh));
+    }
+
+    [Fact]
+    public void ReusedContextLoadsDependenciesWithoutManifests()
+    {
+        using var directory = new TestPluginDirectory();
+
+        foreach (var manifest in Directory.EnumerateFiles(directory.DirectoryPath, "*.deps.json"))
+            File.Delete(manifest);
+
+        var instance = PluginContext.CreateInstanceInReusedContext(directory.SecondType);
+        var dependency = ReadProperty<Type>(instance, "DependencyType");
+        Assert.Same(ContextOf(instance), AssemblyLoadContext.GetLoadContext(dependency.Assembly));
+    }
+
+    [Fact]
+    public void ReusedContextDoesNotInspectUnrelatedManifestsOrDlls()
+    {
+        using var directory = new TestPluginDirectory();
+
+        File.WriteAllText(Path.Combine(directory.DirectoryPath, "Unrelated.deps.json"), "Invalid JSON");
+        File.WriteAllText(Path.Combine(directory.DirectoryPath, "Unrelated.dll"), "Not an assembly");
+        var first = PluginContext.CreateInstanceInReusedContext(directory.FirstType);
+        var second = PluginContext.CreateInstanceInReusedContext(directory.SecondType);
+
+        Assert.Same(ContextOf(first), ContextOf(second));
+        Assert.Equal(1, ReadProperty<int>(first, "Sequence"));
+        Assert.Equal(2, ReadProperty<int>(second, "Sequence"));
+    }
+
+    [Fact]
+    public void ReusedContextLoadsAssemblyNotListedInTheFirstManifest()
+    {
+        using var directory = new TestPluginDirectory();
+        var firstType = directory.FirstType;
+        var requestedName = directory.SecondType.Assembly.GetName();
+        var resolver = new AssemblyDependencyResolver(firstType.Assembly.Location);
+        Assert.Null(resolver.ResolveAssemblyToPath(requestedName));
+
+        var instance = PluginContext.CreateInstanceInReusedContext(firstType);
+        var context = ContextOf(instance);
+        var assembly = context.LoadFromAssemblyName(requestedName);
+
+        Assert.Equal(Path.Combine(directory.DirectoryPath, SecondAssemblyName + ".dll"), assembly.Location);
+        Assert.Same(context, AssemblyLoadContext.GetLoadContext(assembly));
+    }
+
+    [Fact]
+    public void DirectoryKeyIgnoresPathCaseAndSegments()
+    {
+        using var directory = new TestPluginDirectory();
+        var first = PluginContext.CreateInstanceInReusedContext(directory.FirstType);
+        var source = new AssemblyLoadContext("Case variant", isCollectible: true);
+
+        try
+        {
+            var path = Path.Combine(directory.DirectoryPath, ".", FirstAssemblyName + ".dll").ToUpperInvariant();
+            var type = source.LoadFromAssemblyPath(path).GetType(FirstAssemblyName + ".FirstPlugin")!;
+            var second = PluginContext.CreateInstanceInReusedContext(type);
+            Assert.Same(ContextOf(first), ContextOf(second));
+        }
+        finally
+        {
+            source.Unload();
+        }
+    }
+
+    [Fact]
+    public void MissingDependencyIsReportedWithoutFallingBackToSourceContext()
+    {
+        using var directory = new TestPluginDirectory();
+        File.Delete(Path.Combine(directory.DirectoryPath, DependencyAssemblyName + ".dll"));
+        var exception = Assert.ThrowsAny<Exception>(() => PluginContext.CreateInstanceInReusedContext(directory.SecondType));
+        Assert.IsType<FileNotFoundException>(exception.GetBaseException());
+    }
+
+    [Fact]
+    public void NewContextStillResolvesPrivateAssetsFromManifest()
+    {
+        using var directory = new TestPluginDirectory();
+        var privateDirectory = Path.Combine(directory.DirectoryPath, "private");
+        Directory.CreateDirectory(privateDirectory);
+        var dependencyPath = Path.Combine(privateDirectory, DependencyAssemblyName + ".dll");
+        File.Move(Path.Combine(directory.DirectoryPath, DependencyAssemblyName + ".dll"), dependencyPath);
+        directory.SetDependencyAsset(SecondAssemblyName, "private/" + DependencyAssemblyName + ".dll");
+
+        var instance = PluginContext.CreateInstanceInNewContext(directory.SecondType);
+
+        Assert.NotNull(instance);
+        Assert.Equal(dependencyPath, ReadProperty<Type>(instance!, "DependencyType").Assembly.Location);
+    }
+
+    [Fact]
+    public void ReusedContextPrefersManifestPathToFileInDirectory()
+    {
+        using var directory = new TestPluginDirectory();
+        var privateDirectory = Path.Combine(directory.DirectoryPath, "private");
+        Directory.CreateDirectory(privateDirectory);
+        var dependencyPath = Path.Combine(directory.DirectoryPath, DependencyAssemblyName + ".dll");
+        File.Copy(dependencyPath, Path.Combine(privateDirectory, DependencyAssemblyName + ".dll"));
+        directory.SetDependencyAsset(SecondAssemblyName, "private/" + DependencyAssemblyName + ".dll");
+
+        var first = PluginContext.CreateInstanceInReusedContext(directory.SecondType);
+        var second = PluginContext.CreateInstanceInReusedContext(directory.FirstType);
+
+        Assert.Equal(Path.Combine(privateDirectory, DependencyAssemblyName + ".dll"),
+            ReadProperty<Type>(first, "DependencyType").Assembly.Location);
+        Assert.Same(ReadProperty<Type>(first, "DependencyType"), ReadProperty<Type>(second, "DependencyType"));
+    }
+
+    [Fact]
+    public void HigherRequestedDependencyVersionCannotUseAnOlderAssembly()
+    {
+        using var directory = new TestPluginDirectory();
+        var instance = PluginContext.CreateInstanceInReusedContext(directory.SecondType);
+        var dependencyName = ReadProperty<Type>(instance, "DependencyType").Assembly.GetName();
+        dependencyName.Version = new Version(2, 0, 0, 0);
+
+        Assert.Throws<FileLoadException>(() => ContextOf(instance).LoadFromAssemblyName(dependencyName));
+    }
+}

--- a/tests/RxBim.Shared.Tests/PluginContextTests.cs
+++ b/tests/RxBim.Shared.Tests/PluginContextTests.cs
@@ -238,13 +238,19 @@ public class PluginContextTests
     }
 
     [Fact]
-    public void HigherRequestedDependencyVersionCannotUseAnOlderAssembly()
+    public void DependencyVersionResolutionMatchesLegacyContext()
     {
         using var directory = new TestPluginDirectory();
-        var instance = PluginContext.CreateInstanceInReusedContext(directory.SecondType);
-        var dependencyName = ReadProperty<Type>(instance, "DependencyType").Assembly.GetName();
+        var legacy = PluginContext.CreateInstanceInNewContext(directory.SecondType)!;
+        var reused = PluginContext.CreateInstanceInReusedContext(directory.SecondType);
+        var dependency = ReadProperty<Type>(reused, "DependencyType").Assembly;
+        var dependencyName = dependency.GetName();
         dependencyName.Version = new Version(2, 0, 0, 0);
 
-        Assert.Throws<FileLoadException>(() => ContextOf(instance).LoadFromAssemblyName(dependencyName));
+        var legacyAssembly = ContextOf(legacy).LoadFromAssemblyName(dependencyName);
+        var reusedAssembly = ContextOf(reused).LoadFromAssemblyName(dependencyName);
+
+        Assert.Equal(legacyAssembly.GetName().FullName, reusedAssembly.GetName().FullName);
+        Assert.Same(dependency, reusedAssembly);
     }
 }

--- a/tests/RxBim.Shared.Tests/PluginContextTests.cs
+++ b/tests/RxBim.Shared.Tests/PluginContextTests.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Threading.Tasks;
 using Xunit;
 using static TestPluginDirectory;
 
@@ -68,20 +67,6 @@ public class PluginContextTests
         Assert.NotSame(ContextOf(first), ContextOf(second));
         Assert.NotEqual(first.GetType(), second.GetType());
         Assert.Equal(1, ReadProperty<int>(second, "Sequence"));
-    }
-
-    [Fact]
-    public async Task ConcurrentCallsCreateExactlyOneContext()
-    {
-        const int numberOfCalls = 24;
-        using var directory = new TestPluginDirectory();
-        var type = directory.FirstType;
-        var objects = await Task.WhenAll(Enumerable.Range(0, numberOfCalls)
-            .Select(_ => Task.Run(() => PluginContext.CreateInstanceInReusedContext(type))));
-
-        Assert.Single(objects.Select(ContextOf).Distinct());
-        Assert.Single(AssemblyLoadContext.All.Where(context => context.Name == ContextOf(objects[0]).Name));
-        Assert.Equal(numberOfCalls, objects.Select(instance => ReadProperty<int>(instance, "Sequence")).Distinct().Count());
     }
 
     [Fact]

--- a/tests/RxBim.Shared.Tests/RxBim.Shared.Tests.csproj
+++ b/tests/RxBim.Shared.Tests/RxBim.Shared.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <NoWarn>CS1591</NoWarn>
+    <Configurations>Debug;Release</Configurations>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Common.Build.Props, $(MSBuildThisFileDirectory)))" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Fixtures\**\*.cs" />
+    <ProjectReference Include="..\..\src\Core\RxBim.Shared\RxBim.Shared.csproj" />
+    <ProjectReference Include="Fixtures\First\RxBim.Shared.Tests.First.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="Fixtures\Second\RxBim.Shared.Tests.Second.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+  <Target Name="CopyPluginFixtures" AfterTargets="Build">
+    <ItemGroup>
+      <PluginFixture Include="Fixtures\First\bin\$(Configuration)\net8.0-windows\*.dll;Fixtures\First\bin\$(Configuration)\net8.0-windows\*.deps.json" />
+      <PluginFixture Include="Fixtures\Second\bin\$(Configuration)\net8.0-windows\*.dll;Fixtures\Second\bin\$(Configuration)\net8.0-windows\*.deps.json" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PluginFixture)" DestinationFolder="$(OutDir)Fixtures" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/tests/RxBim.Shared.Tests/RxBim.Shared.Tests.csproj
+++ b/tests/RxBim.Shared.Tests/RxBim.Shared.Tests.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\src\Core\RxBim.Shared\RxBim.Shared.csproj" />
     <ProjectReference Include="Fixtures\First\RxBim.Shared.Tests.First.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="Fixtures\Second\RxBim.Shared.Tests.Second.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="Fixtures\WpfProbe\RxBim.Shared.Tests.WpfProbe.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <Target Name="CopyPluginFixtures" AfterTargets="CopyFilesToOutputDirectory">
     <ItemGroup>
@@ -24,6 +25,12 @@
     </ItemGroup>
     <Error Condition="'@(PluginFixture)' == ''" Text="Plugin fixtures were not built. Build the fixture projects in RxBim.slnx before running tests." />
     <Copy SourceFiles="@(PluginFixture)" DestinationFolder="$(OutDir)Fixtures" SkipUnchangedFiles="true">
+      <Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
+    </Copy>
+    <ItemGroup>
+      <WpfProbeFile Include="Fixtures\WpfProbe\bin\$(Configuration)\net8.0-windows\*.dll;Fixtures\WpfProbe\bin\$(Configuration)\net8.0-windows\*.json" />
+    </ItemGroup>
+    <Copy SourceFiles="@(WpfProbeFile)" DestinationFolder="$(OutDir)WpfProbe" SkipUnchangedFiles="true">
       <Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
     </Copy>
   </Target>

--- a/tests/RxBim.Shared.Tests/RxBim.Shared.Tests.csproj
+++ b/tests/RxBim.Shared.Tests/RxBim.Shared.Tests.csproj
@@ -17,11 +17,14 @@
     <ProjectReference Include="Fixtures\First\RxBim.Shared.Tests.First.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="Fixtures\Second\RxBim.Shared.Tests.Second.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
-  <Target Name="CopyPluginFixtures" AfterTargets="Build">
+  <Target Name="CopyPluginFixtures" AfterTargets="CopyFilesToOutputDirectory">
     <ItemGroup>
       <PluginFixture Include="Fixtures\First\bin\$(Configuration)\net8.0-windows\*.dll;Fixtures\First\bin\$(Configuration)\net8.0-windows\*.deps.json" />
       <PluginFixture Include="Fixtures\Second\bin\$(Configuration)\net8.0-windows\*.dll;Fixtures\Second\bin\$(Configuration)\net8.0-windows\*.deps.json" />
     </ItemGroup>
-    <Copy SourceFiles="@(PluginFixture)" DestinationFolder="$(OutDir)Fixtures" SkipUnchangedFiles="true" />
+    <Error Condition="'@(PluginFixture)' == ''" Text="Plugin fixtures were not built. Build the fixture projects in RxBim.slnx before running tests." />
+    <Copy SourceFiles="@(PluginFixture)" DestinationFolder="$(OutDir)Fixtures" SkipUnchangedFiles="true">
+      <Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
+    </Copy>
   </Target>
 </Project>

--- a/tests/RxBim.Shared.Tests/TestPluginDirectory.cs
+++ b/tests/RxBim.Shared.Tests/TestPluginDirectory.cs
@@ -1,0 +1,59 @@
+﻿namespace RxBim.Shared.Tests;
+
+using System;
+using System.IO;
+using System.Runtime.Loader;
+using System.Text;
+using System.Text.Json.Nodes;
+
+internal sealed class TestPluginDirectory : IDisposable
+{
+    internal const string FirstAssemblyName = "RxBim.Shared.Tests.First";
+    internal const string SecondAssemblyName = "RxBim.Shared.Tests.Second";
+    internal const string DependencyAssemblyName = "RxBim.Shared.Tests.Dependency";
+    private readonly AssemblyLoadContext _source = new("Fixture source", isCollectible: true);
+
+    public TestPluginDirectory()
+    {
+        // Keep files under the ignored bin directory: non-collectible contexts may lock DLLs until testhost exits.
+        DirectoryPath = Path.Combine(AppContext.BaseDirectory, "TestApplications", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(DirectoryPath);
+
+        foreach (var file in Directory.EnumerateFiles(Path.Combine(AppContext.BaseDirectory, "Fixtures")))
+            File.Copy(file, Path.Combine(DirectoryPath, Path.GetFileName(file)));
+    }
+
+    public string DirectoryPath { get; }
+
+    public Type FirstType => LoadType(FirstAssemblyName, "FirstPlugin");
+
+    public Type SecondType => LoadType(SecondAssemblyName, "SecondPlugin");
+
+    public Type LoadType(string assemblyName, string className)
+    {
+        var assembly = _source.LoadFromAssemblyPath(Path.Combine(DirectoryPath, assemblyName + ".dll"));
+        return assembly.GetType(assemblyName + "." + className, throwOnError: true)!;
+    }
+
+    public void SetDependencyAsset(string entryAssemblyName, string relativePath)
+    {
+        const string targetName = ".NETCoreApp,Version=v8.0";
+        var manifestPath = Path.Combine(DirectoryPath, entryAssemblyName + ".deps.json");
+        var manifest = JsonNode.Parse(File.ReadAllText(manifestPath))!;
+        var dependency = manifest["targets"]![targetName]![DependencyAssemblyName + "/1.0.0"]!.AsObject();
+        dependency.Remove("runtime");
+        dependency["runtimeTargets"] = new JsonObject
+        {
+            [relativePath] = new JsonObject { ["rid"] = "win-x64", ["assetType"] = "runtime" }
+        };
+        File.WriteAllText(manifestPath, manifest.ToJsonString(), new UTF8Encoding(true));
+    }
+
+    public void Dispose() => _source.Unload();
+
+    public static T ReadProperty<T>(object instance, string name) =>
+        (T)instance.GetType().GetProperty(name)!.GetValue(instance)!;
+
+    public static AssemblyLoadContext ContextOf(object instance) =>
+        AssemblyLoadContext.GetLoadContext(instance.GetType().Assembly)!;
+}

--- a/tests/RxBim.Shared.Tests/WpfContextConflictTests.cs
+++ b/tests/RxBim.Shared.Tests/WpfContextConflictTests.cs
@@ -1,0 +1,60 @@
+﻿namespace RxBim.Shared.Tests;
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+public class WpfContextConflictTests
+{
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task XamlTemplateMatchesAcrossCommandsOnlyWhenTheContextIsShared(bool reuse, bool differentDirectories)
+    {
+        using var first = new TestPluginDirectory();
+        using var second = new TestPluginDirectory();
+        var start = new ProcessStartInfo("dotnet")
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        start.ArgumentList.Add(Path.Combine(AppContext.BaseDirectory, "WpfProbe", "RxBim.Shared.Tests.WpfProbe.dll"));
+        start.ArgumentList.Add(first.DirectoryPath);
+        start.ArgumentList.Add(differentDirectories ? second.DirectoryPath : first.DirectoryPath);
+        start.ArgumentList.Add(reuse.ToString());
+
+        // WPF caches assembly/type lookups for the process lifetime. Each case needs a fresh process.
+        using var process = Process.Start(start)!;
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        finally
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+
+        var output = await outputTask;
+        var error = await errorTask;
+        Assert.True(process.ExitCode == 0, $"WPF probe exited with {process.ExitCode}.\n{output}\n{error}");
+        using var result = JsonDocument.Parse(output);
+        var expectedMatch = reuse && !differentDirectories;
+        Assert.True(result.RootElement.GetProperty("FirstTemplateMatches").GetBoolean());
+        Assert.True(result.RootElement.GetProperty("SecondTemplateUsesFirstModel").GetBoolean());
+        Assert.Equal(expectedMatch, result.RootElement.GetProperty("SameModelType").GetBoolean());
+        Assert.Equal(expectedMatch, result.RootElement.GetProperty("SecondTemplateMatches").GetBoolean());
+        Assert.Equal(expectedMatch, result.RootElement.GetProperty("SecondTemplateUsesSecondModel").GetBoolean());
+    }
+}


### PR DESCRIPTION
Опциональное переиспользование контекста приложения в Revit и AutoCAD.  

Сейчас каждый запуск команды в изолированном режиме создает новый контекст загрузки со своими типами и статическим состоянием.

Добавлена настройка ReuseSeparatedContext для приложений и команд на .NET 8. Вместе с RunInSeparatedContext она включает один PluginContext на папку DLL приложения до завершения процесса. Экземпляры команд и DI-контейнеры создаются отдельно для каждого запуска.  
Зависимости ищутся через AssemblyDependencyResolver. Если он не нашёл сборку, выполняется поиск DLL в папке приложения. Поведение по умолчанию сохранено.  
Обновлены примеры Revit и AutoCAD. Добавлены тесты переиспользования, изоляции, параллельного доступа и вызова команд.